### PR TITLE
Extendable vector checkers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# How to contribute
+
+Contributions are welcome.
+
+Please file bug reports and feature requests to https://github.com/metosin/testit/issues.
+
+## Making changes
+
+* Fork the repository on Github
+* Create a topic branch from where you want to base your work (usually the master branch)
+* Check the formatting rules from existing code (no trailing whitepace, mostly default indentation)
+* Ensure any new code is well-tested, and if possible, any issue fixed is covered by one or more new tests
+* Verify that all tests pass using ```lein midje```
+* Push your code to your fork of the repository
+* Make a Pull Request
+
+## Commit messages
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+    - "Add x", "Fix y", "Support z", "Remove x"
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+
+For comprehensive explanation read this [post by Chris Beams](http://chris.beams.io/posts/git-commit/#seven-rules).

--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ The matching is recursive, so this works too:
 
 #### ...and there can be more
 
-The last value in a expectation vector can be a special qualified
-keyword, which is used to lookup a actual vector checker using the
-`testit.core/vector-checker` multimethod. Testit ships with
-`testit.core/and-then-some` value (and a `...` shortcut symbol for it)
+The last value in a expectation vector can be a qualified dispatch key
+to select an actual contains login via `testit.core/vector-contains`
+multimethod. Testit ships with a dispatch key
+`testit.core/and-then-some` (and a `...` shortcut symbol for it)
 that allows any extra values in the end.
 
 For example, these tests all pass:

--- a/README.md
+++ b/README.md
@@ -314,12 +314,17 @@ The matching is recursive, so this works too:
 
 #### ...and there can be more
 
-If the expectation vector ends with symbol `...`, the actual vector can
-contain more elements, they are just ignored. For example, these tests all
-pass:
+The last value in a expectation vector can be a special qualified
+keyword, which is used to lookup a actual vector checker using the
+`testit.core/vector-checker` multimethod. Testit ships with
+`testit.core/and-then-some` value (and a `...` shortcut symbol for it)
+that allows any extra values in the end.
+
+For example, these tests all pass:
 
 ```clj
 (facts
+  [1 2 3] => (contains [1 2 3 :testit.core/and-then-some])
   [1 2 3] => (contains [1 2 3 ...])
   [1 2 3 4] => (contains [1 2 3 ...])
   [1 2 3 4 5] => (contains [1 2 3 ...]))

--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Midje style assertions for clojure.test"
   :license {:name "Eclipse Public License", :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [clj-http "3.4.1" :scope "test"]]
+                 [clj-http "3.5.0" :scope "test"]]
   :test-paths ["test" "examples"])

--- a/test/testit/core_test.clj
+++ b/test/testit/core_test.clj
@@ -38,6 +38,7 @@
   (is (false? ((contains [1 2 3]) [3 2 1])))
   (is (false? ((contains [1 2 3]) [1 2])))
   (is (false? ((contains [1 2 3]) [1 2 3 4])))
+  (is (false? ((contains [1 ... 2]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2 3])))
   (is (true? ((contains [1 2 ...]) [1 2 3 4])))

--- a/test/testit/core_test.clj
+++ b/test/testit/core_test.clj
@@ -41,6 +41,7 @@
   (is (false? ((contains [1 ... 2]) [1 2])))
   (is (false? ((contains [1 ... 2 ...]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2])))
+  (is (false? ((contains [1 2 3 ...]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2 3])))
   (is (true? ((contains [1 2 ...]) [1 2 3 4])))
   (is (true? ((contains {:foo [1 2 3]}) {:foo [1 2 3]})))
@@ -50,6 +51,7 @@
 
 (deftest contains-set-test
   (is (true? ((contains #{1 2 3}) [1 2 3])))
+  (is (false? ((contains #{1 2 3}) [1 2])))
   (is (true? ((contains #{1 2 3}) [1 2 3 4 5])))
   (is (false? ((contains #{0 1 2 3}) [1 2 3 4 5])))
   (is (true? ((contains #{pos? neg? zero?}) [1 -1 0])))

--- a/test/testit/core_test.clj
+++ b/test/testit/core_test.clj
@@ -39,6 +39,7 @@
   (is (false? ((contains [1 2 3]) [1 2])))
   (is (false? ((contains [1 2 3]) [1 2 3 4])))
   (is (false? ((contains [1 ... 2]) [1 2])))
+  (is (false? ((contains [1 ... 2 ...]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2])))
   (is (true? ((contains [1 2 ...]) [1 2 3])))
   (is (true? ((contains [1 2 ...]) [1 2 3 4])))


### PR DESCRIPTION
Instead of magic marker, vector special checking is now extendable.

also, previous version allowed the `...` to be anywhere in the expected vector if it was also in the last position. Like:

```clj
(contains [1 ... 10 ...]) [1 2]) ; => true (matches only 1 and ::then-some)
(contains [1 ... 10]) [1 2]) ; => false (doesn't do ::them-some at all)
```

Also, added CHANGELOG.md & CONTRIBUTING.md
