### PR TITLE
Fix =eventually-in=> arrow with bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.2.1-SNAPSHOT (2018-04-26)
+
+**[compare](https://github.com/metosin/testit/compare/53c6cd7...a698072)**
+
+### Fixed
+
+- ```=eventually-in=>``` arrow now works with ```testit.core/*eventually-timeout-ms*``` / ```testit.core/*eventually-polling-ms*``` bindings

--- a/src/testit/core.clj
+++ b/src/testit/core.clj
@@ -128,7 +128,7 @@
 
 (declare =eventually-in=>)
 (defmethod assert-arrow '=eventually-in=> [{:keys [msg expected actual]}]
-  `(do-report (in/test-in-eventually ~msg ~expected ~actual ~*eventually-polling-ms* ~*eventually-timeout-ms*)))
+  `(do-report (in/test-in-eventually ~msg ~expected ~actual *eventually-polling-ms* *eventually-timeout-ms*)))
 
 ;;
 ;; =throes=>

--- a/test/testit/eventually_test.clj
+++ b/test/testit/eventually_test.clj
@@ -112,6 +112,14 @@
     (fact
       (deref a) =eventually-in=> 1))
 
+  (binding [*eventually-timeout-ms* 2000]
+    (let [a (atom nil)]
+      (future
+        (Thread/sleep 1500)
+        (reset! a 1))
+      (fact "wait for longer than the default timeout ms"
+        (deref a) =eventually-in=> 1)))
+
   (let [a (atom nil)]
     (future
       (Thread/sleep 100)


### PR DESCRIPTION
This PR fixes the problem with =eventually-in=> arrow not working with *eventually-timeout-ms* and *eventually-polling-ms* bindings and adds test case for that.