### PR TITLE
Add style/indent metadata to the three fact* macros

### DIFF
--- a/src/testit/core.cljc
+++ b/src/testit/core.cljc
@@ -29,7 +29,9 @@
 (s/fdef fact
   :args ::fact)
 
-(defmacro fact [& form]
+(defmacro fact
+  {:style/indent 1}
+  [& form]
   (let [{:keys [name value arrow expected]} (s/conform ::fact form)
         msg (or name (str (pr-str value) " " arrow " " expected))]
     `(try
@@ -50,7 +52,9 @@
 (s/fdef facts
   :args ::facts)
 
-(defmacro facts [& form]
+(defmacro facts
+  {:style/indent 1}
+  [& form]
   (let [{:keys [name body]} (s/conform ::facts form)]
     `(testing ~name
        ~@(for [{:keys [value arrow expected]} body]
@@ -64,7 +68,9 @@
 (s/fdef facts-for
   :args ::facts-for)
 
-(defmacro facts-for [& forms]
+(defmacro facts-for
+  {:style/indent 1}
+  [& forms]
   (let [{:keys [name form-to-test fact-forms]} (s/conform ::facts-for forms)
         result (gensym)]
     `(testing ~name


### PR DESCRIPTION
Taken from this [Indentation Specification](https://docs.cider.mx/cider/indent_spec.html)